### PR TITLE
Incorrect permission for vouchertypes

### DIFF
--- a/src/GiftVoucher.php
+++ b/src/GiftVoucher.php
@@ -93,7 +93,7 @@ class GiftVoucher extends Plugin
             ];
         }
 
-        if (Craft::$app->getUser()->checkPermission('giftVoucher-manageVouchers')) {
+        if (Craft::$app->getUser()->checkPermission('giftVoucher-manageVoucherTypes')) {
             $navItems['subnav']['voucherTypes'] = [
                 'label' => Craft::t('gift-voucher', 'Voucher Types'),
                 'url' => 'gift-voucher/voucher-types',


### PR DESCRIPTION
Voucher types are shown in plugin submenu when user has the manageVouchers permission.