### PR TITLE
Fix missing order properties for PDFs generated in CP

### DIFF
--- a/src/controllers/DownloadsController.php
+++ b/src/controllers/DownloadsController.php
@@ -52,6 +52,7 @@ class DownloadsController extends Controller
 
         if ($codeId) {
             $codes = [Craft::$app->getElements()->getElementById($codeId)];
+            $order = $codes[0]->order;
         }
 
         $pdf = GiftVoucher::getInstance()->getPdf()->renderPdf($codes, $order, $lineItem, $option);


### PR DESCRIPTION
Voucher PDFs generated from Voucher Code edit pages render without order properties in the filenames because the PDF link only sends the `codeId` param. Need to add `$order = $codes[0]->order;` or similar so that an order gets passed to filename generation when a PDF is requested from the control panel.