### PR TITLE
Update GiftVoucher.php

### DIFF
--- a/src/GiftVoucher.php
+++ b/src/GiftVoucher.php
@@ -147,7 +147,7 @@ class GiftVoucher extends Plugin
         Event::on(LineItem::class, LineItem::EVENT_BEFORE_VALIDATE, [$this->getCodes(), 'handleValidateLineItem']);
 
         // Klaviyo Connect Plugin
-        if (class_exists(Track::class)) {
+        if (Craft::$app->plugins->getPlugin('klaviyoconnect') && class_exists(Track::class)) {
             Event::on(Track::class, Track::ADD_LINE_ITEM_CUSTOM_PROPERTIES, [$this->getKlaviyoConnect(), 'addLineItemCustomProperties']);
         }
     }


### PR DESCRIPTION
Adds a check to make sure the Klaviyo Connect plugin is installed before attempting to add the event listener. 

I ran into this when I attempted to add Klaviyo Connect to a project that already has Gift Voucher installed. I believe it's because the class will exist when the Klaviyo plugin exists in the autoloader, but then the event listener fails because the plugin isn't installed yet.

You might be able to just change the line to check for the plugin, but I figured it didn't hurt to check for the class as well.