### PR TITLE
Fix ErrorException from undefined variable uid

### DIFF
--- a/src/GiftVoucher.php
+++ b/src/GiftVoucher.php
@@ -192,8 +192,8 @@ class GiftVoucher extends Plugin
 
             $voucherTypePermissions = [];
 
-            foreach ($voucherTypes as $id => $voucherType) {
-                $suffix = ':' . $uid;
+            foreach ($voucherTypes as $voucherType) {
+                $suffix = ':' . $voucherType->uid;
                 $voucherTypePermissions['giftVoucher-manageVoucherType' . $suffix] = ['label' => Craft::t('gift-voucher', 'Manage “{type}” vouchers', ['type' => $voucherType->name])];
             }
 


### PR DESCRIPTION
Since 2.4.2 opening a user edit page in the CP produces an ErrorException with the message `Undefined variable: uid`. Fixed this error and cleaned up the foreach loop since the `$id` was no longer used.