### PR TITLE
Replace hard coded currency with order currency

### DIFF
--- a/src/templates/codes/_fields.html
+++ b/src/templates/codes/_fields.html
@@ -91,7 +91,11 @@
                     </td>
 
                     <td class="nowrap" width="10%">
-                        ${{ redemption.amount }}
+                        {{ redemption.amount|commerceCurrency(
+                            redemption.getOrder().currency,
+                            convert=true
+                            )
+                        }}
                     </td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
HI!

I replaced the hard coded "$" sign in voucher code control panel leftover value with current order currency, by using Craft commerceCurrency filter.

Best regards