### PR TITLE
Update PluginTrait.php

### DIFF
--- a/src/base/PluginTrait.php
+++ b/src/base/PluginTrait.php
@@ -59,6 +59,11 @@ trait PluginTrait
     {
         return $this->get('codeStorage');
     }
+    
+    public function getKlaviyoConnect()
+    {
+        return $this->get('klaviyoConnect');
+    }
 
     public static function log($message)
     {


### PR DESCRIPTION
I'm not sure when exactly this happened, but I recently updated the plugin and started to run into some 

```
Calling unknown method: verbb\giftvoucher\GiftVoucher::getKlaviyoConnect()
```
 errors, it looks like the `getKlaviyoConnect` method got forgotten somewhere