### PR TITLE
Bugfix: rename Order to OrderCodeStorage

### DIFF
--- a/src/storage/OrderCodeStorage.php
+++ b/src/storage/OrderCodeStorage.php
@@ -10,7 +10,7 @@ use craft\commerce\elements\Order;
 
 use yii\helpers\ArrayHelper;
 
-class Order extends Component implements CodeStorageInterface
+class OrderCodeStorage extends Component implements CodeStorageInterface
 {
     // Properties
     // =========================================================================


### PR DESCRIPTION
This is causing problems because it is using the Commerce Order Element in a class named Order, so I renamed it.

@brianjhanson has a similar PR out that should fix this as well!

<img width="1440" alt="Screen Shot 2020-11-17 at 2 20 20 PM" src="https://user-images.githubusercontent.com/10780725/99460238-5d6cd480-28e4-11eb-878e-461bd8eca017.png">
