### PR TITLE
Adding voucher code bulk generation

### DIFF
--- a/src/GiftVoucher.php
+++ b/src/GiftVoucher.php
@@ -130,6 +130,13 @@ class GiftVoucher extends Plugin
             ];
         }
 
+        if (Craft::$app->getUser()->checkPermission('giftVoucher-manageCodes')) {
+            $navItems['subnav']['bulk-generate'] = [
+                'label' => Craft::t('gift-voucher', 'Bulk generate codes'),
+                'url' => 'gift-voucher/codes/bulk-generate',
+            ];
+        }
+
         if (Craft::$app->getUser()->getIsAdmin() && Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
             $navItems['subnav']['settings'] = [
                 'label' => Craft::t('gift-voucher', 'Settings'),
@@ -292,7 +299,7 @@ class GiftVoucher extends Plugin
         $projectConfigService->onAdd(VoucherTypes::CONFIG_VOUCHERTYPES_KEY . '.{uid}', [$voucherTypeService, 'handleChangedVoucherType'])
             ->onUpdate(VoucherTypes::CONFIG_VOUCHERTYPES_KEY . '.{uid}', [$voucherTypeService, 'handleChangedVoucherType'])
             ->onRemove(VoucherTypes::CONFIG_VOUCHERTYPES_KEY . '.{uid}', [$voucherTypeService, 'handleDeletedVoucherType']);
-        
+
         $projectConfigService->onAdd(CodesService::CONFIG_FIELDLAYOUT_KEY, [$codesService, 'handleChangedFieldLayout'])
             ->onUpdate(CodesService::CONFIG_FIELDLAYOUT_KEY, [$codesService, 'handleChangedFieldLayout'])
             ->onRemove(CodesService::CONFIG_FIELDLAYOUT_KEY, [$codesService, 'handleDeletedFieldLayout']);
@@ -320,6 +327,8 @@ class GiftVoucher extends Plugin
 
                 'gift-voucher/codes/new' => 'gift-voucher/codes/edit',
                 'gift-voucher/codes/<codeId:\d+>' => 'gift-voucher/codes/edit',
+
+                'gift-voucher/codes/bulk-generate' => 'gift-voucher/codes/bulk-generate',
 
                 'gift-voucher/settings' => 'gift-voucher/base/settings',
             ]);

--- a/src/templates/codes/_bulk-generate.html
+++ b/src/templates/codes/_bulk-generate.html
@@ -1,0 +1,86 @@
+{% extends 'gift-voucher/_layouts' %}
+{% import '_includes/forms' as forms %}
+
+{% set crumbs = [
+	{ label: 'Gift Voucher'|t('gift-voucher'), url: url('gift-voucher') },
+	{ label: 'Voucher codes'|t('app'), url: url('gift-voucher/codes') },
+	{ label: 'Bulk generate'|t('app'), url: url('gift-voucher/codes/bulk-generate') }
+] %}
+
+{% set selectedSubnavItem = 'bulk-generate' %}
+
+{% set title = 'Bulk generate codes'|t('gift-voucher') %}
+{% set noTabs = true %}
+{% set fullPageForm = true %}
+
+{% block actionButton %}{% endblock %}
+
+{% block blockContent %}
+	{{ actionInput('gift-voucher/codes/bulk-generate-submit') }}
+	{{ redirectInput('gift-voucher/codes/bulk-generate') }}
+
+	<div id="fields">
+		{{ forms.textField({
+			first: true,
+			label: 'Amount of voucher codes'|t('gift-voucher'),
+			instructions: 'How many voucher codes would you like to generate?'|t('gift-voucher'),
+			id: 'amount',
+			name: 'amount',
+			value: null,
+			errors: errors.amount is defined ? errors.amount : [],
+			autofocus: true,
+			required: true,
+		}) }}
+		
+		{% js %}
+			{% set voucherTypes = [] %}
+			{% for voucherType in craft.giftVoucher.getEditableVoucherTypes() %}
+				{% set voucherTypes = voucherTypes|merge([{
+					id: voucherType.id,
+					name: voucherType.name,
+					handle: voucherType.handle,
+				}]) %}
+			{% endfor %}
+			
+			Craft.GiftVoucher.editableVoucherTypes = {{ voucherTypes|json_encode|raw }};
+		{% endjs %}
+		
+		{{ forms.elementSelectField({
+			label: 'Voucher'|t('gift-voucher'),
+			instructions: 'Select a voucher to be associated with the generated voucher codes.'|t('gift-voucher'),
+			elementType: voucherElementType,
+			id: 'voucher',
+			class: 'ltr',
+			name: 'voucher',
+			required: true,
+			limit: 1,
+			addButtonLabel: 'Select a Voucher'|t('gift-voucher'),
+			errors: errors.voucher is defined ? errors.voucher : [],
+		}) }}
+		
+		{{ forms.textField({
+			label: 'Voucher amount'|t('gift-voucher'),
+			instructions: 'Define an amount for the value of the voucher code.'|t('gift-voucher'),
+			id: 'voucherAmount',
+			name: 'voucherAmount',
+			value: null,
+			errors: errors.voucherAmount is defined ? errors.voucherAmount : [],
+			required: true,
+		}) }}
+		
+		{{ forms.dateTimeField({
+			label: 'Expiry date'|t('gift-voucher'),
+			instructions: 'Optionally, enter the date for the voucher codes to expire.',
+			id: 'expiryDate',
+			name: 'expiryDate',
+			value: null,
+			errors: errors.expiryDate is defined ? errors.expiryDate : [],
+		}) }}
+	</div>
+{% endblock %}
+
+{% block footerButton %}
+	<div class="buttons">
+		<input type="submit" class="btn submit" value="{{ 'Generate codes'|t('gift-voucher') }}">
+	</div>
+{% endblock %}


### PR DESCRIPTION
Following a request of one of our clients, I've added an additional page in the control panel of the plugin to be able to bulk generate voucher codes. With an amount of codes, a specific voucher, the desired voucher value and an optional expiry date.

![Schermafbeelding 2021-03-18 om 11 02 06](https://user-images.githubusercontent.com/4600095/111608355-678ed900-87d9-11eb-91bf-405fe6f2272d.png)

I did consider moving the code generation into a Craft-job. However, our projects run their jobs in a cronjob or daemon, so it would take some time to start generating them. Also, the usually not-so-technically-skilled-clients might be confused as the form is submitted and the voucher codes are not immediately showing up because the job is still running. This might be a future improvement, showing the generation progress in some nice UI after submitting the form, but I did not have the time available at this moment.

It would be nice if this could be merged back into your plugin, thanks!