### PR TITLE
Fix "cannot assign Dompdf\Options to property

### DIFF
--- a/src/events/PdfRenderOptionsEvent.php
+++ b/src/events/PdfRenderOptionsEvent.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace verbb\giftvoucher\events;
 
+use Dompdf\Options;
 use yii\base\Event;
 
 class PdfRenderOptionsEvent extends Event
 {
-    public array $options = [];
+    public array|Options $options = [];
 }


### PR DESCRIPTION
…options

Fix bug where plugin was setting the $options to Dompdf\Options class, but is limited to array. So added the Dompdf\Options to the option

This action will fail `/actions/gift-voucher/downloads/pdf` if it's not adjusted