### PR TITLE
Exclude shipping adjustments on line items when includeShipping is false

### DIFF
--- a/src/adjusters/GiftVoucherAdjuster.php
+++ b/src/adjusters/GiftVoucherAdjuster.php
@@ -43,7 +43,7 @@ class GiftVoucherAdjuster extends Component implements AdjusterInterface
         if ($settings->includeShipping) {
             $this->_orderTotal = $order->getTotalPrice();
         } else {
-            $this->_orderTotal = $order->getItemTotal();
+            $this->_orderTotal = $this->_getItemTotalWithoutShipping($order);
         }
 
         // Get code by session
@@ -141,5 +141,13 @@ class GiftVoucherAdjuster extends Component implements AdjusterInterface
         $this->_orderTotal += $adjustment->amount;
 
         return $adjustment;
+    }
+
+    private function _getItemTotalWithoutShipping(Order $order): float
+    {
+        $itemTotal = $order->getItemTotal();
+        $shippingTotal = $order->getTotalShippingCost();
+
+        return $itemTotal - $shippingTotal;
     }
 }


### PR DESCRIPTION
This updates the recent change to exclude shipping adjustments from the voucher adjustment to also exclude shipping adjustments on line items.

Relates to https://github.com/verbb/gift-voucher/issues/63#issuecomment-2870543373

`getItemTotal` includes all adjustments on line items. This change subtracts the result of `getTotalShippingCost` from that amount. `getTotalShippingCost` should include all `"shipping"` adjustments, both on the order and for line items.