### PR TITLE
Fix: Correctly deduct line item shipping amounts

### DIFF
--- a/src/adjusters/GiftVoucherAdjuster.php
+++ b/src/adjusters/GiftVoucherAdjuster.php
@@ -146,7 +146,12 @@ class GiftVoucherAdjuster extends Component implements AdjusterInterface
     private function _getItemTotalWithoutShipping(Order $order): float
     {
         $itemTotal = $order->getItemTotal();
-        $shippingTotal = $order->getTotalShippingCost();
+        
+        foreach ($order->getAdjustments() as $adjustment) {
+            if ($adjustment->type === 'shipping' && $adjustment->lineItem) {
+                $itemTotal -= $adjustment->amount;
+            }
+        }
 
         return $itemTotal - $shippingTotal;
     }

--- a/src/adjusters/GiftVoucherAdjuster.php
+++ b/src/adjusters/GiftVoucherAdjuster.php
@@ -153,6 +153,6 @@ class GiftVoucherAdjuster extends Component implements AdjusterInterface
             }
         }
 
-        return $itemTotal - $shippingTotal;
+        return $itemTotal;
     }
 }


### PR DESCRIPTION
This corrects the previously accepted PR #140 where order level shipping was deducted twice.

This works because `getItemTotal()` is _only_ totals of the items in the order, including their adjustments. It doesn't include order level adjustments. Previous to this PR, `_getItemTotalWithoutShipping` was removing order level shipping cost even though it was not in `getItemTotal()`. This resulted in the order level shipping cost from being deducted twice in the end.