### PR TITLE
Add EVENT_AFTER_BULK_GENERATE_CODES

### DIFF
--- a/docs/developers/events.md
+++ b/docs/developers/events.md
@@ -157,6 +157,20 @@ Event::on(Code::class, Code::EVENT_GENERATE_CODE_KEY, function(GenerateCodeEvent
 });
 ```
 
+### The `afterBulkGenerateCodesEvent` event
+Plugins can get a list of all codes that were generated in a bulk operation.
+
+```php
+use verbb\giftvoucher\elements\Code;
+use verbb\giftvoucher\events\BulkGenerateCodesEvent;
+use verbb\giftvoucher\GiftVoucher;
+use yii\base\Event;
+
+Event::on(Code::class, Code::EVENT_AFTER_BULK_GENERATE_CODES, function(BulkGenerateCodesEvent $event) {
+    $codes = $event->codes;
+});
+```
+
 ### The `beforeSaveCode` event
 Plugins can get notified before a code is saved. Event handlers can prevent the code from getting sent by setting `$event->isValid` to false.
 

--- a/docs/developers/events.md
+++ b/docs/developers/events.md
@@ -161,12 +161,12 @@ Event::on(Code::class, Code::EVENT_GENERATE_CODE_KEY, function(GenerateCodeEvent
 Plugins can get a list of all codes that were generated in a bulk operation.
 
 ```php
-use verbb\giftvoucher\elements\Code;
+use verbb\giftvoucher\controllers\CodesController;
 use verbb\giftvoucher\events\BulkGenerateCodesEvent;
 use verbb\giftvoucher\GiftVoucher;
 use yii\base\Event;
 
-Event::on(Code::class, Code::EVENT_AFTER_BULK_GENERATE_CODES, function(BulkGenerateCodesEvent $event) {
+Event::on(CodesController::class, CodesController::EVENT_AFTER_BULK_GENERATE_CODES, function(BulkGenerateCodesEvent $event) {
     $codes = $event->codes;
 });
 ```

--- a/src/controllers/CodesController.php
+++ b/src/controllers/CodesController.php
@@ -17,6 +17,12 @@ use yii\web\Response;
 
 class CodesController extends Controller
 {
+    // Constants
+    // =========================================================================
+
+    public const EVENT_AFTER_BULK_GENERATE_CODES = 'afterBulkGenerateCodesEvent';
+
+    
     // Public Methods
     // =========================================================================
 
@@ -252,8 +258,8 @@ class CodesController extends Controller
         $bulkGenerateCodesEvent = new BulkGenerateCodesEvent(['codes' => $savedCodes]);
 
         // Raising the 'afterBulkGenerateCodesEvent' event
-        if ($this->hasEventHandlers(Code::EVENT_AFTER_BULK_GENERATE_CODES)) {
-            $this->trigger(Code::EVENT_AFTER_BULK_GENERATE_CODES, $bulkGenerateCodesEvent);
+        if ($this->hasEventHandlers(self::EVENT_AFTER_BULK_GENERATE_CODES)) {
+            $this->trigger(self::EVENT_AFTER_BULK_GENERATE_CODES, $bulkGenerateCodesEvent);
         }
 
         Craft::$app->getSession()->setNotice(Craft::t('gift-voucher', 'Voucher codes generated.'));

--- a/src/controllers/CodesController.php
+++ b/src/controllers/CodesController.php
@@ -4,6 +4,7 @@ namespace verbb\giftvoucher\controllers;
 use verbb\giftvoucher\GiftVoucher;
 use verbb\giftvoucher\elements\Code;
 use verbb\giftvoucher\elements\Voucher;
+use verbb\giftvoucher\events\BulkGenerateCodesEvent;
 
 use Craft;
 use craft\base\Element;
@@ -245,13 +246,20 @@ class CodesController extends Controller
                 return null;
             }
 
-            $savedCodes[] = $code->id;
+            $savedCodes[] = $code;
+        }
+        
+        $bulkGenerateCodesEvent = new BulkGenerateCodesEvent(['codes' => $savedCodes]);
+
+        // Raising the 'afterBulkGenerateCodesEvent' event
+        if ($this->hasEventHandlers(Code::EVENT_AFTER_BULK_GENERATE_CODES)) {
+            $this->trigger(Code::EVENT_AFTER_BULK_GENERATE_CODES, $bulkGenerateCodesEvent);
         }
 
         Craft::$app->getSession()->setNotice(Craft::t('gift-voucher', 'Voucher codes generated.'));
 
         return $this->redirect(UrlHelper::url('gift-voucher/codes/bulk-generate-success', [
-            'savedCodes' => implode('_', $savedCodes),
+            'savedCodes' => implode('_', array_map(fn($code): int => $code->id, $savedCodes)),
         ]));
     }
 }

--- a/src/elements/Code.php
+++ b/src/elements/Code.php
@@ -34,6 +34,7 @@ class Code extends Element
     // =========================================================================
 
     public const EVENT_GENERATE_CODE_KEY = 'beforeGenerateCodeKey';
+    public const EVENT_AFTER_BULK_GENERATE_CODES = 'afterBulkGenerateCodesEvent';
 
 
     // Static Methods

--- a/src/elements/Code.php
+++ b/src/elements/Code.php
@@ -34,7 +34,6 @@ class Code extends Element
     // =========================================================================
 
     public const EVENT_GENERATE_CODE_KEY = 'beforeGenerateCodeKey';
-    public const EVENT_AFTER_BULK_GENERATE_CODES = 'afterBulkGenerateCodesEvent';
 
 
     // Static Methods

--- a/src/events/BulkGenerateCodesEvent.php
+++ b/src/events/BulkGenerateCodesEvent.php
@@ -1,0 +1,13 @@
+<?php
+namespace verbb\giftvoucher\events;
+
+use yii\base\Event;
+
+class BulkGenerateCodesEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    public array $codes;
+
+}


### PR DESCRIPTION
We were in need to get all codes after bulk generation (e.g. to create a CSV and send it per mail to person XY), so I've added this. Would be nice if it could be merged into the official repository!