### PR TITLE
Multisite Fixes

### DIFF
--- a/src/GiftVoucher.php
+++ b/src/GiftVoucher.php
@@ -51,6 +51,7 @@ use yii\base\Event;
 
 use fostercommerce\klaviyoconnect\services\Track;
 use fostercommerce\klaviyoconnect\models\EventProperties;
+use verbb\giftvoucher\twig\CpExtensions;
 
 class GiftVoucher extends Plugin
 {
@@ -88,6 +89,7 @@ class GiftVoucher extends Plugin
 
         if (Craft::$app->getRequest()->getIsCpRequest()) {
             $this->_registerCpRoutes();
+            $this->_registerCpTwigExtensions();
             $this->_registerFieldLayoutListener();
         }
 
@@ -352,6 +354,11 @@ class GiftVoucher extends Plugin
                 'gift-voucher/settings' => 'gift-voucher/base/settings',
             ]);
         });
+    }
+    
+    private function _registerCpTwigExtensions(): void
+    {
+        Craft::$app->view->registerTwigExtension(new CpExtensions());
     }
 
     private function _registerFieldLayoutListener(): void

--- a/src/elements/Code.php
+++ b/src/elements/Code.php
@@ -2,6 +2,7 @@
 namespace verbb\giftvoucher\elements;
 
 use verbb\giftvoucher\GiftVoucher;
+use verbb\giftvoucher\elements\conditions\CodeConditions;
 use verbb\giftvoucher\elements\db\CodeQuery;
 use verbb\giftvoucher\events\GenerateCodeEvent;
 use verbb\giftvoucher\records\Code as CodeRecord;
@@ -23,7 +24,7 @@ use craft\validators\DateTimeValidator;
 use craft\commerce\Plugin as Commerce;
 use craft\commerce\elements\Order;
 use craft\commerce\models\LineItem;
-
+use craft\elements\conditions\ElementConditionInterface;
 use yii\base\InvalidConfigException;
 
 use DateTime;
@@ -429,6 +430,10 @@ class Code extends Element
         parent::afterSave($isNew);
     }
 
+    public static function createCondition(): ElementConditionInterface
+    {
+        return Craft::createObject(CodeConditions::class, [static::class]);
+    }
 
     // Protected Methods
     // =========================================================================

--- a/src/elements/conditions/CodeConditions.php
+++ b/src/elements/conditions/CodeConditions.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace verbb\giftvoucher\elements\conditions;
+
+use craft\elements\conditions\ElementCondition;
+
+/**
+ * Code conditions
+ */
+final class CodeConditions extends ElementCondition {
+    protected function selectableConditionRules(): array {
+        return array_merge(parent::selectableConditionRules(), [
+            Voucher::class,
+        ]);
+    }
+}

--- a/src/elements/conditions/Voucher.php
+++ b/src/elements/conditions/Voucher.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace verbb\giftvoucher\elements\conditions;
+
+use Craft;
+use craft\base\conditions\BaseElementSelectConditionRule;
+use craft\base\ElementInterface;
+use craft\elements\conditions\ElementConditionRuleInterface;
+use craft\elements\db\ElementQueryInterface;
+use verbb\giftvoucher\elements\db\CodeQuery;
+use verbb\giftvoucher\elements\Voucher as ElementsVoucher;
+
+/**
+ * Voucher element condition rule
+ */
+final class Voucher extends BaseElementSelectConditionRule implements ElementConditionRuleInterface {
+    public function getLabel(): string {
+        return Craft::t('gift-voucher', 'Gift Voucher');
+    }
+
+    public function getExclusiveQueryParams(): array {
+        return ['voucherId'];
+    }
+
+    public function modifyQuery(ElementQueryInterface $query): void {
+        /** @var CodeQuery $query */
+        $query->voucherId($this->getElementId());
+    }
+
+    public function matchElement(ElementInterface $element): bool {
+        /** @var ElementsVoucher $element */
+        return $this->matchValue($element->id);
+    }
+
+    protected function elementType(): string {
+        return ElementsVoucher::class;
+    }
+
+    protected function sources(): ?array {
+        return null;
+    }
+
+    protected function criteria(): ?array {
+        return null;
+    }
+}

--- a/src/templates/codes/_bulk-generate.html
+++ b/src/templates/codes/_bulk-generate.html
@@ -1,11 +1,44 @@
 {% extends 'gift-voucher/_layouts' %}
 {% import '_includes/forms' as forms %}
 
-{% set crumbs = [
+{% if selectableSites is not defined %}
+    {% if siteIds is defined %}
+        {% set selectableSites = craft.app.sites.getEditableSites()|filter(s => s.id in siteIds) %}
+    {% else %}
+        {% set selectableSites = craft.app.sites.getEditableSites() %}
+    {% endif %}
+{% endif %}
+
+{% if selectedSite is not defined %}
+    {% if selectedSiteId is defined %}
+        {% set selectedSite = craft.app.sites.getSiteById(selectedSiteId) %}
+    {% elseif requestedSite and requestedSite in selectableSites %}
+        {% set selectedSite = requestedSite %}
+    {% else %}
+        {% set selectedSite = selectableSites|length ? selectableSites|first : craft.app.sites.getPrimarySite() %}
+    {% endif %}
+{% endif %}
+
+{% if craft.app.getIsMultiSite() %}
+    {% set crumbs = [{
+        id: 'site-crumb',
+        icon: 'world',
+        iconAltText: 'Site'|t('app'),
+        label: selectedSite.name|t('site'),
+        menu: {
+            items: siteMenuItems(selectableSites, selectedSite),
+            label: 'Select site'|t('app')
+        }
+    }] %}
+{% else %}
+    {% set crumbs = [] %}
+{% endif %}
+
+{% set crumbs = crumbs|merge([
 	{ label: 'Gift Voucher' | t('gift-voucher'), url: url('gift-voucher') },
 	{ label: 'Voucher Codes' | t('gift-voucher'), url: url('gift-voucher/codes') },
 	{ label: 'Bulk Generate' | t('gift-voucher'), url: url('gift-voucher/codes/bulk-generate') }
-] %}
+]) %}
 
 {% set selectedSubnavItem = 'bulk-generate' %}
 

--- a/src/templates/codes/_edit.html
+++ b/src/templates/codes/_edit.html
@@ -95,15 +95,6 @@
             name: 'enabled',
             on: code.enabled,
         }) }}
-
-        {% if craft.app.getIsMultiSite() %}
-            {{ forms.lightswitchField({
-                label: 'Enabled for site' | t('gift-voucher'),
-                id: 'enabledForSite',
-                name: 'enabledForSite',
-                on: code.enabledForSite,
-            }) }}
-        {% endif %}
     </div>
 
     <hr>

--- a/src/templates/codes/bulk-generate-success.html
+++ b/src/templates/codes/bulk-generate-success.html
@@ -1,11 +1,44 @@
 {% extends 'gift-voucher/_layouts' %}
 {% import '_includes/forms' as forms %}
 
-{% set crumbs = [
+{% if selectableSites is not defined %}
+    {% if siteIds is defined %}
+        {% set selectableSites = craft.app.sites.getEditableSites()|filter(s => s.id in siteIds) %}
+    {% else %}
+        {% set selectableSites = craft.app.sites.getEditableSites() %}
+    {% endif %}
+{% endif %}
+
+{% if selectedSite is not defined %}
+    {% if selectedSiteId is defined %}
+        {% set selectedSite = craft.app.sites.getSiteById(selectedSiteId) %}
+    {% elseif requestedSite and requestedSite in selectableSites %}
+        {% set selectedSite = requestedSite %}
+    {% else %}
+        {% set selectedSite = selectableSites|length ? selectableSites|first : craft.app.sites.getPrimarySite() %}
+    {% endif %}
+{% endif %}
+
+{% if craft.app.getIsMultiSite() %}
+    {% set crumbs = [{
+        id: 'site-crumb',
+        icon: 'world',
+        iconAltText: 'Site'|t('app'),
+        label: selectedSite.name|t('site'),
+        menu: {
+            items: siteMenuItems(selectableSites, selectedSite),
+            label: 'Select site'|t('app')
+        }
+    }] %}
+{% else %}
+    {% set crumbs = [] %}
+{% endif %}
+
+{% set crumbs = crumbs|merge([
     { label: 'Gift Voucher' | t('gift-voucher'), url: url('gift-voucher') },
     { label: 'Voucher Codes' | t('gift-voucher'), url: url('gift-voucher/codes') },
     { label: 'Bulk Generate' | t('gift-voucher'), url: url('gift-voucher/codes/bulk-generate') }
-] %}
+]) %}
 
 {% set selectedSubnavItem = 'bulk-generate' %}
 

--- a/src/templates/codes/index.html
+++ b/src/templates/codes/index.html
@@ -6,4 +6,17 @@
 {% set docTitle = title ~ ' - Gift Voucher' %}
 {% set elementType = 'verbb\\giftvoucher\\elements\\Code' %}
 
+{% js %}
+	{% set voucherTypes = [] %}
+	{% for voucherType in craft.giftVoucher.getEditableVoucherTypes() %}
+		{% set voucherTypes = voucherTypes | merge([{
+			id: voucherType.id,
+			name: voucherType.name,
+			handle: voucherType.handle,
+		}]) %}
+	{% endfor %}
+	
+	Craft.GiftVoucher.editableVoucherTypes = {{ voucherTypes | json_encode | raw }};
+{% endjs %}
+
 {% do view.registerAssetBundle('verbb\\giftvoucher\\assetbundles\\GiftVoucherAsset') -%}

--- a/src/templates/vouchers/_edit.html
+++ b/src/templates/vouchers/_edit.html
@@ -19,20 +19,25 @@
     {% endif %}
 {% endif %}
 
-{% set crumbs = [
-{
-    id: 'site-crumb',
-    icon: 'world',
-    iconAltText: 'Site'|t('app'),
-    label: selectedSite.name|t('site'),
-    menu: {
-        items: giftVoucherSiteMenu(siteMenuItems(selectableSites, selectedSite), enabledSiteIds, url("gift-voucher/vouchers/#{voucherTypeHandle}/#{craft.app.request.getSegment(4)}")),
-        label: 'Select site'|t('app')
-    }
-},
+{% if craft.app.getIsMultiSite() %}
+    {% set crumbs = [{
+        id: 'site-crumb',
+        icon: 'world',
+        iconAltText: 'Site'|t('app'),
+        label: selectedSite.name|t('site'),
+        menu: {
+            items: giftVoucherSiteMenu(siteMenuItems(selectableSites, selectedSite), enabledSiteIds, url("gift-voucher/vouchers/#{voucherTypeHandle}/#{craft.app.request.getSegment(4)}")),
+            label: 'Select site'|t('app')
+        }
+    }] %}
+{% else %}
+    {% set crumbs = [] %}
+{% endif %}
+
+{% set crumbs = crumbs|merge([
 	{ label: 'Gift Voucher' | t('gift-voucher'), url: url('gift-voucher') },
 	{ label: voucherType.name | t('gift-voucher'), url: url('gift-voucher/vouchers/' ~ voucherType.handle) },
-] %}
+]) %}
 
 {% set fullPageForm = true %}
 {% set saveShortcutRedirect = continueEditingUrl %}

--- a/src/templates/vouchers/_edit.html
+++ b/src/templates/vouchers/_edit.html
@@ -1,7 +1,35 @@
 {% extends '_layouts/cp' %}
 {% set selectedSubnavItem = 'vouchers' %}
 
+{% if selectableSites is not defined %}
+    {% if siteIds is defined %}
+        {% set selectableSites = craft.app.sites.getEditableSites()|filter(s => s.id in siteIds) %}
+    {% else %}
+        {% set selectableSites = craft.app.sites.getEditableSites() %}
+    {% endif %}
+{% endif %}
+
+{% if selectedSite is not defined %}
+    {% if selectedSiteId is defined %}
+        {% set selectedSite = craft.app.sites.getSiteById(selectedSiteId) %}
+    {% elseif requestedSite and requestedSite in selectableSites %}
+        {% set selectedSite = requestedSite %}
+    {% else %}
+        {% set selectedSite = selectableSites|length ? selectableSites|first : craft.app.sites.getPrimarySite() %}
+    {% endif %}
+{% endif %}
+
 {% set crumbs = [
+{
+    id: 'site-crumb',
+    icon: 'world',
+    iconAltText: 'Site'|t('app'),
+    label: selectedSite.name|t('site'),
+    menu: {
+        items: giftVoucherSiteMenu(siteMenuItems(selectableSites, selectedSite), enabledSiteIds, url("gift-voucher/vouchers/#{voucherTypeHandle}/#{craft.app.request.getSegment(4)}")),
+        label: 'Select site'|t('app')
+    }
+},
 	{ label: 'Gift Voucher' | t('gift-voucher'), url: url('gift-voucher') },
 	{ label: voucherType.name | t('gift-voucher'), url: url('gift-voucher/vouchers/' ~ voucherType.handle) },
 ] %}
@@ -36,31 +64,6 @@
 {% endblock %}
 
 {% block contextMenu %}
-    {% if craft.app.getIsMultiSite() %}
-        <div class="btn menubtn sitemenubtn" data-icon="world">{{ voucher.site.name | t('site') }}</div>
-        <div class="menu">
-            <ul class="padded">
-                {% for siteId in siteIds %}
-                    {% set site = craft.app.sites.getSiteById(siteId) %}
-                    {% set status = siteId in enabledSiteIds ? 'enabled' : 'disabled' %}
-
-                    <li>
-                        {% if siteId == voucher.siteId %}
-                            <a class="sel" data-site-id="{{ siteId }}">
-                                <div class="status {{ status }}"></div>{{ site.name | t('site') }}
-                            </a>
-                        {% else %}
-                            {% set url = url("gift-voucher/vouchers/#{voucherTypeHandle}/#{craft.app.request.getSegment(4)}/#{site.handle}") %}
-
-                            <a href="{{ url }}" data-site-id="{{ siteId }}">
-                                <div class="status {{ status }}"></div>{{ site.name | t('site') }}
-                            </a>
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
-        </div>
-    {% endif %}
 {% endblock %}
 
 {% block actionButton %}

--- a/src/twig/CpExtensions.php
+++ b/src/twig/CpExtensions.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace verbb\giftvoucher\twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class CpExtensions extends AbstractExtension {
+    public function getFunctions(): array {
+        return [
+            new TwigFunction('giftVoucherSiteMenu', [$this, 'giftVoucherSiteMenu']),
+        ];
+    }
+
+    public function giftVoucherSiteMenu(array $siteMenu, array $enabledSiteIds, string $absoluteUrl): array {
+        // remove the query string from the given absolute URL
+        $absoluteUrl = parse_url($absoluteUrl, PHP_URL_PATH);
+
+        // step through
+        $this->updateUrlsRecursive(
+            $siteMenu,
+            $absoluteUrl,
+            $enabledSiteIds,
+            // set the correct URL
+            function (string $url, string $absoluteUrl) {
+                $parsedUrl = parse_url($url);
+                parse_str($parsedUrl['query'], $parsedQuery);
+                $site = $parsedQuery['site'];
+
+                return $absoluteUrl . '/' . $site . '?site=' . $site;
+            },
+            // set the status
+            function (int|null $siteId, array $enabledSiteIds) {
+                if ($siteId === null) {
+                    return;
+                }
+
+                if (in_array($siteId, $enabledSiteIds)) {
+                    return 'enabled';
+                }
+
+                return 'disabled';
+            },
+        );
+
+        return $siteMenu;
+    }
+
+    private function updateUrlsRecursive(array &$array, string $absoluteUrl, array $enabledSiteIds, callable $urlCallback, callable $statusCallback): void {
+        foreach ($array as $key => &$value) {
+            if (is_array($value)) {
+                $this->updateUrlsRecursive($value, $absoluteUrl, $enabledSiteIds, $urlCallback, $statusCallback);
+            } elseif ($key === 'url') {
+                $value = $urlCallback($value, $absoluteUrl);
+            } elseif ($key === 'status') {
+                $siteId = null;
+                if (isset($array['attributes']['data']['site-id'])) {
+                    $siteId = $array['attributes']['data']['site-id'];
+                }
+
+                $value = $statusCallback($siteId, $enabledSiteIds);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello 👋 I've made some changes to improve multisite handling:

- Codes had an "enabled for site" setting, but Codes aren't meant to enable multisite-wise, so I've removed this option (it wasn't even saved when changed)
- Changing the site inside a voucher now works with Craft's native site-dropdown. It takes care of the special URLs that this plugin uses and also shows the status of each site
- Bulk generate templates now also have the site-dropdown. Even if it's not really necessary here, it provides a consistent experience if you navigate through backend views on a multisite
- I've fixed a script error when using the search filter in the code elements index view
- I've added a new element condition to filter codes by their voucher in the code elements index view