### PR TITLE
Only test line items which are not custom line items when searching for a Voucher purchasable

### DIFF
--- a/src/services/Vouchers.php
+++ b/src/services/Vouchers.php
@@ -1,6 +1,7 @@
 <?php
 namespace verbb\giftvoucher\services;
 
+use craft\commerce\enums\LineItemType;
 use verbb\giftvoucher\GiftVoucher;
 use verbb\giftvoucher\elements\Voucher;
 
@@ -67,7 +68,7 @@ class Vouchers extends Component
             $hasVoucher = false;
 
             foreach ($order->lineItems as $lineItem) {
-                if (is_a($lineItem->purchasable, Voucher::class)) {
+                if ($lineItem->type === LineItemType::Purchasable && is_a($lineItem->purchasable, Voucher::class)) {
                     $hasVoucher = true;
 
                     break;


### PR DESCRIPTION
On orders with Custom line items, the onBeforeSendEmail silently fails, but leaves a log message:

```
[web.ERROR] [verbb\giftvoucher\services\Vouchers::onBeforeSendEmail] PDF unable to be attached to “New order received” for order “xxxxxxx”. Error: Cannot get a purchasable for a custom line item /vendor/craftcms/commerce/src/models/LineItem.php:838
```

This change excludes Custom lineitems from the check since they don't have purchasables, and attempting to fetch a purchasable on a custom lineitme results in the "Cannot get a purchasable for a custom line item" error.